### PR TITLE
Little fixes

### DIFF
--- a/fsm-editor/src/com/mxgraph/examples/swing/editor/fileimportexport/SCXMLImportExport.java
+++ b/fsm-editor/src/com/mxgraph/examples/swing/editor/fileimportexport/SCXMLImportExport.java
@@ -697,7 +697,7 @@ public class SCXMLImportExport implements IImportExport {
 		String close="";
 		if (!isRoot || value.shouldThisRootBeSaved()) {
 			if (isRoot) {
-				ret="<scxml version=\"0.9\"";
+				ret="<scxml version=\"1.0\"";
 				close="</scxml>";
 			} else if (value.isParallel()) {
 				ret="<parallel";

--- a/fsm-editor/src/com/mxgraph/examples/swing/editor/scxml/SCXMLEditorMenuBar.java
+++ b/fsm-editor/src/com/mxgraph/examples/swing/editor/scxml/SCXMLEditorMenuBar.java
@@ -166,7 +166,7 @@ public class SCXMLEditorMenuBar extends JMenuBar
 						"Institute for Creative Technologies\n"+
 						"University of Southern California\n\n"+
 						"Contributions by:\n" +
-						"Társi Róbert, Alerant Zrt (Hungary)\n";
+						"TÃ¡rsi RÃ³bert, Alerant Zrt (Hungary)\n";
 				try {
 					
 					info=mxUtils.readFile(mxUtils.getURIForResourceNamed("info.txt"));

--- a/fsm-editor/src/com/mxgraph/examples/swing/editor/scxml/eleditor/SCXMLOutEdgeOrderEditor.java
+++ b/fsm-editor/src/com/mxgraph/examples/swing/editor/scxml/eleditor/SCXMLOutEdgeOrderEditor.java
@@ -108,7 +108,7 @@ public class SCXMLOutEdgeOrderEditor extends JDialog implements ListSelectionLis
 	public class CloseAction extends AbstractAction {
 		public void actionPerformed(ActionEvent e) {
 			SCXMLOutEdgeOrderEditor.this.actionPerformed(new ActionEvent(this, 0, "cancel"));
-			editor.setEditorForCellAndType(cell, Type.OUTGOING_EDGE_ORDER, null);
+			editor.setEditorForCellAndType(cell, SCXMLElementEditor.Type.OUTGOING_EDGE_ORDER, null);
 		}
 	}
 	


### PR DESCRIPTION
We need to output version="1.0" in order to generate valid scxml, and because of the character set problems and the enum qualification it didn't compile here.